### PR TITLE
Fix II detection bug

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
+\.drone\.jsonnet
 _pkgdown\.yml
 Makefile
 ^test\.R$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: lastdose
 Type: Package
 Title: Calculate Time and Amount of Last Dose
-Version: 0.3.0
+Version: 0.3.0.9000
 Authors@R: c(
     person("Kyle T", "Baron", email = "kyleb@metrumrg.com", role=c("aut", "cre"), comment=c(ORCID="0000-0001-7252-5656"))
     )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# lastdose (development version)
+
 # lastdose 0.3.0
 
 - Add `time_col` and `id_col` arguments to let user name columns containing 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # lastdose (development version)
 
+- Fix bug where `II` column was not properly detected resulting in incorrect 
+  `TAD` calculation when doses were also scheduled via `ADDL` #21
+  
 # lastdose 0.3.0
 
 - Add `time_col` and `id_col` arguments to let user name columns containing 

--- a/R/lastdose.R
+++ b/R/lastdose.R
@@ -185,7 +185,7 @@ lastdose_list <- function(data,
   if(!is.numeric(col_addl)) {
     stop("column ADDL/addl is required to be numeric", call.=FALSE)
   }
-  wii <- match("ii", na)
+  wii <- match("ii", lcna)
   if(is.na(wii)) {
     col_ii <- vector(mode = "numeric", length=nrow(data))
     wii <- NULL

--- a/R/lastdose.R
+++ b/R/lastdose.R
@@ -121,10 +121,8 @@ lastdose_list <- function(data,
   }
   addl_ties <- match.arg(addl_ties)
   sort1 <- addl_ties == "obs_first"
-  x <- as.data.frame(data)
-  na <- names(data)
-  lcna <- tolower(na)
-  wid <- match(id_col, na)
+  lcna <- tolower(names(data))
+  wid <- match(id_col, names(data))
   if(is.na(wid)) {
     stop("did not find id column `", id_col, "` in `data`", call.=FALSE)
   }
@@ -135,7 +133,7 @@ lastdose_list <- function(data,
   if(!is.numeric(col_id)) {
     stop("id column is required to be numeric", call.=FALSE)
   }
-  wtime <- match(time_col, na)
+  wtime <- match(time_col, names(data))
   if(is.na(wtime)) {
     stop("did not find time column `", time_col, "` in `data`", call.=FALSE)
   }

--- a/R/lastdose.R
+++ b/R/lastdose.R
@@ -121,7 +121,7 @@ lastdose_list <- function(data,
   }
   addl_ties <- match.arg(addl_ties)
   sort1 <- addl_ties == "obs_first"
-  lcna <- tolower(names(data))
+  lower_names <- tolower(names(data))
   wid <- match(id_col, names(data))
   if(is.na(wid)) {
     stop("did not find id column `", id_col, "` in `data`", call.=FALSE)
@@ -157,7 +157,7 @@ lastdose_list <- function(data,
   if(!is.numeric(col_time)) {
     stop("time column is required to be numeric", call.=FALSE)
   }
-  wamt <- match("amt", lcna)
+  wamt <- match("amt", lower_names)
   if(is.na(wamt)) {
     stop("column AMT or amt is required in the data set", call.=FALSE)
   }
@@ -165,7 +165,7 @@ lastdose_list <- function(data,
   if(!is.numeric(col_amt)) {
     stop("column AMT/amt is required to be numeric", call.=FALSE)
   }
-  wevid <- match("evid",lcna)
+  wevid <- match("evid", lower_names)
   if(is.na(wevid)) {
     stop("column EVID or evid is required in the data set.", call.=FALSE)
   }
@@ -173,7 +173,7 @@ lastdose_list <- function(data,
   if(!is.numeric(col_evid)) {
     stop("column EVID/evid is required to be numeric", call.=FALSE)
   }
-  waddl <- match("addl", lcna)
+  waddl <- match("addl", lower_names)
   if(is.na(waddl)) {
     col_addl <- vector(mode = "numeric", length=nrow(data))
     wii <- NULL
@@ -183,7 +183,7 @@ lastdose_list <- function(data,
   if(!is.numeric(col_addl)) {
     stop("column ADDL/addl is required to be numeric", call.=FALSE)
   }
-  wii <- match("ii", lcna)
+  wii <- match("ii", lower_names)
   if(is.na(wii)) {
     col_ii <- vector(mode = "numeric", length=nrow(data))
     wii <- NULL

--- a/src/lastdose.cpp
+++ b/src/lastdose.cpp
@@ -140,6 +140,14 @@ Rcpp::List lastdose_impl(Rcpp::NumericVector id,
       this_rec.pos = crow;
       this_id.push_back(this_rec);
       if((addl[j] > 0) && this_rec.is_dose()) {
+        if(ii[j] <= 0.0) {
+          throw Rcpp::exception(
+              tfm::format(
+                "ADDL doses requested, but II is not positive at row %i", (j+1)
+              ).c_str(),
+              false
+          );
+        }
         for(int k = 0; k < addl[j]; ++k) {
           record addl_rec(0.0,amt[j],evid[j],false,false);
           addl_rec.time = time[j] + ii[j]*double(k+1);

--- a/tests/testthat/test-lastdose.R
+++ b/tests/testthat/test-lastdose.R
@@ -225,3 +225,18 @@ test_that("ii detection issue-21", {
   term <- subset(out, TIME >=5)
   expect_equal(term$TAD, c(0,1,2,3))
 })
+
+test_that("error if ADDL requested by II lt 0", {
+  data <- data.frame(
+    TIME = c(0,1,2,3),
+    AMT  = c(0,1,0,0),
+    EVID = c(0,1,0,0),
+    ADDL = c(0,2,0,0),
+    II   = 0,
+    ID = 1
+  )
+  expect_error(
+    lastdose(data),
+    msg = "ADDL doses requested, but II not positive at row 2"
+  )
+})

--- a/tests/testthat/test-lastdose.R
+++ b/tests/testthat/test-lastdose.R
@@ -192,3 +192,36 @@ test_that("logical comment column is ok", {
   d$C <- sample(c(1, 2), nrow(d), replace = TRUE)
   expect_warning(lastdose(d), msg = "but it wasn't character or logical")
 })
+
+test_that("ii detection issue-21", {
+  data <- data.frame(
+    TIME = c(0,1,2,3,4,5,6,7,8),
+    AMT  = c(0,1,0,0,0,0,0,0,0),
+    EVID = c(0,1,0,0,0,0,0,0,0),
+    II   = c(0,2,0,0,0,0,0,0,0),
+    ADDL = c(0,2,0,0,0,0,0,0,0),
+    ID = 1
+  )
+  out <- lastdose(data, addl_ties = "dose_first")
+  expect_true(all(out$LDOS[-1]==1))
+  expect_equal(out$TAD[1],-1)
+  doses <- subset(out, TIME %in% c(1,3,5))
+  expect_true(all(doses$TAD==0))
+  ones <- subset(out, TIME %in% c(2,4,6))
+  expect_true(all(ones$TAD==1))
+  term <- subset(out, TIME >=5)
+  expect_equal(term$TAD, c(0,1,2,3))
+  data2 <- data
+  II <- data2$II
+  data2$II <- NULL
+  data2$ii <- II
+  out <- lastdose(data2, addl_ties = "dose_first")
+  expect_true(all(out$LDOS[-1]==1))
+  expect_equal(out$TAD[1],-1)
+  doses <- subset(out, TIME %in% c(1,3,5))
+  expect_true(all(doses$TAD==0))
+  ones <- subset(out, TIME %in% c(2,4,6))
+  expect_true(all(ones$TAD==1))
+  term <- subset(out, TIME >=5)
+  expect_equal(term$TAD, c(0,1,2,3))
+})

--- a/tests/testthat/test-lastdose.R
+++ b/tests/testthat/test-lastdose.R
@@ -226,7 +226,7 @@ test_that("ii detection issue-21", {
   expect_equal(term$TAD, c(0,1,2,3))
 })
 
-test_that("error if ADDL requested by II lt 0", {
+test_that("error if ADDL requested by II le 0", {
   data <- data.frame(
     TIME = c(0,1,2,3),
     AMT  = c(0,1,0,0),


### PR DESCRIPTION
See #21 

In the last version, I refactored the code for detecting input column names.  This code looked at the wrong variable when looking for `ii` or `II`.  This resulted in the II col not being picked up. 

This also refactors some of the code a bit for safety (removing a variable that could be mistaken in the future).  Also adds error when ADDL doses are requested by II is <= 0.