### PR TITLE
subset comments vector after finding missing times

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # lastdose (development version)
 
 - Fix bug where comments vector wasn't getting adjusted when `TIME` contained
-  missing values (#38, #39)
+  missing values (#38, #39).
 
 # lastdose 0.4.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # lastdose (development version)
 
+- Fix bug where comments vector wasn't getting adjusted when `TIME` contained
+  missing values (#38, #39)
+
 # lastdose 0.4.0
 
 - Change default value for `include_tafd` to FALSE (#29)

--- a/R/lastdose.R
+++ b/R/lastdose.R
@@ -172,6 +172,7 @@ lastdose_list <- function(data,
   if(has_na_time) {
     na_time <- is.na(data[[wtime]])
     data <- data[!na_time,, drop = FALSE]
+    comments <- comments[!na_time]
   }
   col_time <- data[[wtime]]
   if(inherits(col_time, "POSIXct")) {

--- a/inst/validation/lastdose-stories.yaml
+++ b/inst/validation/lastdose-stories.yaml
@@ -1,3 +1,15 @@
+# Please add stories at the top ------------------------------------------
+
+LSD-S015:
+  name: Comments vector not adjusted for missing TIME
+  description: >
+    As a user, I want lastdose to properly accommodate comments and missing
+    values in the TIME column.
+  ProductRisk: low-risk
+  tests:
+  - LSD-TEST-025
+
+# Initial set of tests --------------------------------------------------
 LSD-S001:
   name: Add TAD and LDOS to data set
   description: As a user, I want lastdose to add time after dose and last dose amount

--- a/tests/testthat/test-lastdose.R
+++ b/tests/testthat/test-lastdose.R
@@ -347,3 +347,15 @@ test_that("error if ADDL requested by II le 0 [LSD-TEST-024]", {
     msg = "ADDL doses requested, but II not positive at row 2"
   )
 })
+
+test_that("comments vector is subset for NA time #38 [LSD-TEST-025]", {
+  data <- data.frame(
+    ID = c(1,1,1,2,2,2),
+    C = c("C", NA, NA, "C", NA, NA),
+    TIME = c(-1, 0, NA, -1, 0, 0.25),
+    AMT = c(0, 100, 0, 0, 200, 0),
+    EVID = c(0, 1, 0, 0, 1, 0)
+  )
+  data <- lastdose(data)
+  expect_equal(data$TAD, c(-1, 0, NA, -1, 0, 0.25))
+})


### PR DESCRIPTION
# Summary
This fixes a bug reported by @bmreilly ; the root cause was failure to subset the `comments` vector after finding missing times

``` r
library(lastdose)

data <- data.frame(
  ID = c(1,1,1,2,2,2),
  C = c("C", NA, NA, "C", NA, NA),
  TIME = c(-1, 0, NA, -1, 0, 0.25),
  AMT = c(0, 100, 0, 0, 200, 0),
  EVID = c(0, 1, 0, 0, 1, 0)
)


lastdose(data)
#>   ID    C  TIME AMT EVID   TAD LDOS
#> 1  1    C -1.00   0    0 -1.00    0
#> 2  1 <NA>  0.00 100    1  0.00  100
#> 3  1 <NA>    NA   0    0    NA   NA
#> 4  2    C -1.00   0    0 -1.00    0
#> 5  2 <NA>  0.00 200    1  0.00  200
#> 6  2 <NA>  0.25   0    0  0.25  200
```

<sup>Created on 2022-05-05 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>