### PR TITLE
Clone amount in case it is modified

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,6 @@ BugReports: https://github.com/metrumresearchgroup/lastdose/issues
 Suggests: testthat, withr
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 Language: en-US

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: lastdose
 Type: Package
 Title: Calculate Time and Amount of Last Dose
-Version: 0.4.1
+Version: 0.4.1.9000
 Authors@R: c(
     person("Kyle T", "Baron", email = "kyleb@metrumrg.com", role=c("aut", "cre"), comment=c(ORCID="0000-0001-7252-5656"))
     )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # lastdose (development version)
 
+## Bugs Fixed
+
+- Fixed bug where `amt` was getting modified in source data frame 
+  when it contained missing values (#40, #41).
+
 # lastdose 0.4.1
 
 - Fix bug where comments vector wasn't getting adjusted when `TIME` contained

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# lastdose (development version)
+
 # lastdose 0.4.1
 
 - Fix bug where comments vector wasn't getting adjusted when `TIME` contained

--- a/src/lastdose.cpp
+++ b/src/lastdose.cpp
@@ -59,6 +59,7 @@ Rcpp::List lastdose_impl(Rcpp::NumericVector id,
                          Rcpp::LogicalVector sort1,
                          Rcpp::LogicalVector comment) {
 
+  amt = Rcpp::clone(amt);
   bool use_comp1 = sort1[0];
   bool use_fill = !back_calc[0];
   std::vector<double> idn;

--- a/tests/testthat/test-lastdose.R
+++ b/tests/testthat/test-lastdose.R
@@ -359,3 +359,21 @@ test_that("comments vector is subset for NA time #38 [LSD-TEST-025]", {
   data <- lastdose(data)
   expect_equal(data$TAD, c(-1, 0, NA, -1, 0, 0.25))
 })
+
+test_that("data frame is not modified", {
+  data <- data.frame(
+    ID = 1,
+    AMT = c(0, 1, NA, 0, 0),
+    TIME = c(1, 2, 3, 4, 5),
+    EVID = c(0, 1, 0, 0, 0)
+  )
+  data2 <- data.frame(
+    ID = 1,
+    AMT = c(0, 1, NA, 0, 0),
+    TIME = c(1, 2, 3, 4, 5),
+    EVID = c(0, 1, 0, 0, 0)
+  )
+  expect_identical(data, data2)
+  ld <- lastdose(data)
+  expect_identical(data, data2)
+})


### PR DESCRIPTION
# Summary

When `amt` contains missing values, they need to be filled with `0` and they are in the C++ code. However, the data passed to the C++ code were still pointers to the columns in the data frame and the source data frame was getting modified (see #40). 

This PR implements a `clone()` step so `amt` isn't modified in the source data frame. 
