### PR TITLE
ci: update ubuntu-20.04 jobs to ubuntu-22.04

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             r: 3.6.3
             # Under the latest testthat, this fails with an obscure
             # waldo error ("object 'compare_proxy' not found").
@@ -26,13 +26,13 @@ jobs:
             devtools_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2020-10-24/src/contrib/devtools_2.3.2.tar.gz'
             # Latest rhub requires R 4.0.
             rhub_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2020-10-24/src/contrib/rhub_1.1.1.tar.gz'
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             r: 4.0.5
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             r: 4.1.3
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             r: 4.2.3
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             r: 4.3.1
           - os: ubuntu-latest
             r: release

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,11 +19,6 @@ jobs:
         config:
           - os: ubuntu-22.04
             r: 3.6.3
-            # Under the latest testthat, this fails with an obscure
-            # waldo error ("object 'compare_proxy' not found").
-            testthat_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2020-10-24/src/contrib/testthat_2.3.2.tar.gz'
-            # Latest devtools requires a newer testthat.
-            devtools_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2020-10-24/src/contrib/devtools_2.3.2.tar.gz'
             # Latest rhub requires R 4.0.
             rhub_pkg: 'url::https://mpn.metworx.com/snapshots/stable/2020-10-24/src/contrib/rhub_1.1.1.tar.gz'
           - os: ubuntu-22.04
@@ -49,8 +44,6 @@ jobs:
           extra-packages: |
             any::pkgdown
             any::rcmdcheck
-            ${{ matrix.config.testthat_pkg }}
-            ${{ matrix.config.devtools_pkg }}
             ${{ matrix.config.rhub_pkg }}
           upgrade: ${{ matrix.config.r == '3.6.3' && 'FALSE' || 'TRUE' }}
       - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
The ubuntu-20.04 image is deprecated as of 2025-02-01 and is scheduled to be retired on 2025-04-01.

https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions