### PR TITLE
Release 0.5.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: lastdose
 Type: Package
 Title: Calculate Time and Amount of Last Dose
-Version: 0.4.3
+Version: 0.5.0
 Authors@R: c(
     person("Kyle T", "Baron", email = "kyleb@metrumrg.com", role=c("aut", "cre"), comment=c(ORCID="0000-0001-7252-5656"))
     )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,12 @@
-# lastdose (development version)
+# lastdose 0.5.0
+
+- `lastdose()`, `lastdose_list()`, and `lastdose_df()` output now include 
+  observation occasion (`OCC`) (#49).
+
+## Bugs fixed
+
+- Refactored how records are sorted to ensure original order is maintained when
+  several records have the same time within an individual (#47).
 
 # lastdose 0.4.3
 


### PR DESCRIPTION
# lastdose 0.5.0

- `lastdose()`, `lastdose_list()`, and `lastdose_df()` output now include 
  observation occasion (`OCC`) (#49).

## Bugs fixed

- Refactored how records are sorted to ensure original order is maintained when
  several records have the same time within an individual (#47).